### PR TITLE
Added a missing '#if USE_KEYMAPS_IN_EEPROM' in zeal60.c

### DIFF
--- a/keyboards/zeal60/zeal60.c
+++ b/keyboards/zeal60/zeal60.c
@@ -142,7 +142,9 @@ void matrix_init_kb(void)
 
 		// This saves "empty" keymaps so it falls back to the keymaps
 		// in the firmware (aka. progmem/flash)
+#if USE_KEYMAPS_IN_EEPROM
 		keymap_default_save();
+#endif
 
 		// Save the magic number last, in case saving was interrupted
 		eeprom_set_valid(true);


### PR DESCRIPTION
The firmware fails to build when USE_KEYMAPS_IN_EEPROM is set to 0 since the function `keymap_default_save()` doesn't exist then, but it's called in `matrix_init_kb`. Adding a simple `#if USE_KEYMAPS_IN_EEPROM` fixes this.