### PR TITLE
Feature/add bootloader command

### DIFF
--- a/keyboards/zeal60/zeal60.c
+++ b/keyboards/zeal60/zeal60.c
@@ -116,6 +116,17 @@ void bootmagic_lite(void)
 		// Jump to bootloader.
 		bootloader_jump();
 	}
+
+        // If Esc, 1, and 2 keys are held down on power up,
+        // jump to thebootloader. Assumes Esc is at [0,0], 1
+        // is at [0,1], and 2 is at [0,2].
+        if ( ( matrix_get_row(0) & (1<<0) ) &&
+                ( matrix_get_row(0) & (1<<1) ) &&
+                ( matrix_get_row(0) & (1<<2) ) )
+        {
+                // Jump to bootloader.
+                bootloader_jump();
+        }
 }
 
 void matrix_init_kb(void)


### PR DESCRIPTION
Adding a bootup key combo (Esc, 1, and 2 keys held on boot) to jump directly to the bootloader without having to either access the button the PCB or resetting the EEPROM.

If there is another way to do this, I apologize for the noise! I couldn't find any specific documentation for this keyboard and the default bootloader key combos I tried didn't work.